### PR TITLE
Fix RoboVM gradle plugin version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 buildscript {
+  // Defined here so that we can use it in the buildscript block
+  project.ext.roboVMVersion = '2.3.5'
 
   repositories {
     mavenLocal()
@@ -10,7 +12,7 @@ buildscript {
   dependencies {
     classpath "org.wisepersist:gwt-gradle-plugin:1.0.6"
     classpath "com.android.tools.build:gradle:3.1.3"
-    classpath "com.mobidevelop.robovm:robovm-gradle-plugin:2.3.3"
+    classpath "com.mobidevelop.robovm:robovm-gradle-plugin:$roboVMVersion"
   }
 }
 
@@ -26,7 +28,6 @@ allprojects {
   ext {
     appName = "playn-gradle-template"
     playnVersion = "2.1-SNAPSHOT"
-    roboVMVersion = "2.3.3"
     gwtVersion = "2.8.0"
   }
 }


### PR DESCRIPTION
Define roboVMVersion early so that we can use it also
for the RoboVM gradle plugin. While we are at it, update
this to the latest release (2.3.5)